### PR TITLE
Dynamic board - player color transparency added

### DIFF
--- a/scripts/clickBox.js
+++ b/scripts/clickBox.js
@@ -9,7 +9,8 @@ const clickBox = event => {
 
         let counter = concatedPlayersArray.length
 
-        let currentPlayer = (counter % 2 === 0 ? {'player':'X', 'arrayIndex': 0, 'color': 'red'} : {'player':'O', 'arrayIndex': 1, 'color': 'blue'})
+        let currentPlayer = (counter % 2 === 0 ? {'player':'X', 'arrayIndex': 0, 'color': 'red', 'colorTransparent': 
+        'rgba(255, 0, 0, 0.800)'} : {'player':'O', 'arrayIndex': 1, 'color': 'blue', 'colorTransparent': 'rgba(0, 0, 255, 0.800)'})
 
         playersArray[currentPlayer.arrayIndex].push(boxId)
 

--- a/scripts/results.js
+++ b/scripts/results.js
@@ -13,7 +13,7 @@ const displayResult = function(winner, winningArray) {
     }
     else {
         victoryDisplay(winningArray);
-        displayWinner(winner.player, winner.color);
+        displayWinner(winner.player, winner.colorTransparent);
     }
 
 }

--- a/scripts/victory.js
+++ b/scripts/victory.js
@@ -1,5 +1,3 @@
-let winnerArray;
-
 const victoryCheck = (array,boxes) => {
     
     let winningArray = null

--- a/scripts/winningArray.js
+++ b/scripts/winningArray.js
@@ -1,5 +1,5 @@
 const buildArray = x => {
-    winnerArray = []
+    let winnerArray = []
 
     for (let index = 0; index < x; index++) {
         let counter = x*index+1

--- a/styles/flipping.css
+++ b/styles/flipping.css
@@ -4,6 +4,8 @@
 .flip-container,
 .flip-container-sm {
     perspective: 1000px;
+    color: rgba(255, 0, 0, 0.700);
+    color: rgba(0, 0, 255, 0.700);
 }
 
 


### PR DESCRIPTION
I'm not sure if this is something we want or like, but I added another property to the player object that holds a slightly transparent version of each player's color. When the game is over and the winner is shown in the popup box, the box background color is now slightly transparent. 

To Test:
1. get fetch --all and checkout into dynamic-board_PlayerColorTweaks
1. load http-server
1. play game and get X to win, then get O to win and see if the color of winner box is slightly transparent

I won't be offended is we think this isn't needed. :) I thought this would help me get a good idea how all the code is flowing together, from function to function. 